### PR TITLE
Stop Spawning Random Buildings

### DIFF
--- a/common/on_action/game_start.txt
+++ b/common/on_action/game_start.txt
@@ -7282,7 +7282,7 @@ on_game_start_after_lobby = {
 				limit = {
 					has_holding = yes
 				}
-				generate_building = yes
+				#generate_building = yes
 				brewery_counter_start_effect = yes
 			}
 			every_domicile = {
@@ -7334,63 +7334,63 @@ on_game_start_after_lobby = {
 				limit = {
 					has_holding = yes
 				}
-				generate_building = yes
-				generate_building = yes
-				generate_building = yes
-				generate_building = yes
-				generate_building = yes
-				generate_building = yes
+				#generate_building = yes
+				#generate_building = yes
+				#generate_building = yes
+				#generate_building = yes
+				#generate_building = yes
+				#generate_building = yes
 				if = {
 					limit = {
 						county.development_level >= 8
 					}
-					generate_building = yes
-					generate_building = yes
+					#generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 10
 					}
-					generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 12
 					}
-					generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 14
 					}
-					generate_building = yes
-					generate_building = yes
+					#generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 16
 					}
-					generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 18
 					}
-					generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 20
 					}
-					generate_building = yes
+					#generate_building = yes
 				}
 				if = {
 					limit = {
 						county.development_level >= 25
 					}
-					generate_building = yes
-					generate_building = yes
-					generate_building = yes
+					#generate_building = yes
+					#generate_building = yes
+					#generate_building = yes
 				}
 				brewery_counter_start_effect = yes
 			}


### PR DESCRIPTION
The start year triggers all the Generate Building lines, commenting them out removes all the random buildings at game start. Instead each county capitol has 1 holding appropriate building unless the History adds more.